### PR TITLE
Add navigation link to home

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,9 @@
 <body>
   <header>
     <h1>ようこそ</h1>
+    <nav>
+      <a href="{{ '/' | relative_url }}">トップページへ</a>
+    </nav>
   </header>
   <main>
     {{ content }}


### PR DESCRIPTION
## Summary
- add a navigation element in the default layout with a link to `index.html`

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6850b54bfbc083268d6f21e107e12d20