### PR TITLE
Display page titles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <header>
-    <h1>ようこそ</h1>
+    <h1>{{ page.title }}</h1>
     <nav>
       <a href="{{ '/' | relative_url }}">トップページへ</a>
     </nav>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: ブログ目次
+title: Articles
 ---
 <h1>ブログ記事一覧</h1>
 <ul>


### PR DESCRIPTION
## Summary
- show each page's title in the header
- update index page title to `Articles`

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576bb955c0832681e1e48b4a4ed1f1